### PR TITLE
Persist routeScope

### DIFF
--- a/src/LiveComponent/src/Controller/BatchActionController.php
+++ b/src/LiveComponent/src/Controller/BatchActionController.php
@@ -38,6 +38,7 @@ final class BatchActionController
                 '_component_action_args' => $action['args'] ?? [],
                 '_mounted_component' => $_mounted_component,
                 '_live_component' => $serviceId,
+                '_routeScope' => $request->attributes->get('_routeScope'),
             ]);
 
             $response = $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... 
| License       | MIT

The `routeScope` gets lost when routes are called using the `BatchActionController`
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
